### PR TITLE
Fix Interactive.remove() method for javascript

### DIFF
--- a/src-js/de.bezier.gui.js
+++ b/src-js/de.bezier.gui.js
@@ -142,7 +142,7 @@ var Interactive = (function(){
 
         this.remove = function( listener ) {
             for ( var i = 0, k = this.listeners.length; i < k; i++ ) {
-                if ( this.listeners[i] == listener )
+                if ( this.listeners[i].listener == listener )
                     this.listeners.splice( i, 1 );
             }
         }


### PR DESCRIPTION
I haven't tested the java version of the method. Anyway, the javascript version was broken.

Also, I'm still trying to understand the need for "return ae" in the method, as it always returns null. Should it return the input object when it's a single one?
