### PR TITLE
Two changes to make Guido compatible with Python Mode.

### DIFF
--- a/src/de/bezier/guido/AbstractActiveElement.java
+++ b/src/de/bezier/guido/AbstractActiveElement.java
@@ -18,7 +18,7 @@ public abstract class AbstractActiveElement extends Basic2DElement
 		Interactive.get().addElement( this );
 	}
 	
-	public AbstractActiveElement ( float x, float y, float width, float height ) 
+	public AbstractActiveElement ( float x, float y, float width, float height )
 	{
 		super(x,y,width,height);
 		Interactive.get().addElement( this );
@@ -29,7 +29,7 @@ public abstract class AbstractActiveElement extends Basic2DElement
 		debug = tf;
 	}
 
-	public void setActive ( boolean yesNo ) 
+	public void setActive ( boolean yesNo )
 	{
 		activated = yesNo;
 	}
@@ -62,15 +62,28 @@ public abstract class AbstractActiveElement extends Basic2DElement
 			long now = System.currentTimeMillis();
 			long lp = lastPressed;
 			lastPressed = now;
+			final Interactive manager = Interactive.get();
 			if ( now - lp < 200 )
 			{
-				mouseDoubleClicked( );
-				mouseDoubleClicked( mx, my );
+				if (manager.shouldCallbackWithoutPosition())
+				{
+					mouseDoubleClicked( );
+				}
+				if (manager.shouldCallbackWithPosition())
+				{
+					mouseDoubleClicked( mx, my );
+				}
 			}
 			else
 			{
-				mousePressed( );
-				mousePressed( mx, my );
+				if (manager.shouldCallbackWithoutPosition())
+				{
+					mousePressed( );
+				}
+				if (manager.shouldCallbackWithPosition())
+				{
+					mousePressed( mx, my );
+				}
 			}
 		}
 	}
@@ -85,12 +98,19 @@ public abstract class AbstractActiveElement extends Basic2DElement
 		if ( !isActive() ) return;
 
 		dragged = pressed;
-		if ( dragged ) 
+		if ( dragged )
 		{
 			draggedDistX = clickedMouseX - mx;
 			draggedDistY = clickedMouseY - my;
-			mouseDragged( mx, my );
-			mouseDragged( mx, my, clickedPositionX - draggedDistX, clickedPositionY - draggedDistY );
+			final Interactive manager = Interactive.get();
+			if (manager.shouldCallbackWithoutDelta())
+			{
+				mouseDragged( mx, my );
+			}
+			if (manager.shouldCallbackWithDelta())
+			{
+				mouseDragged( mx, my, clickedPositionX - draggedDistX, clickedPositionY - draggedDistY );
+			}
 		}
 	}
 	
@@ -101,15 +121,24 @@ public abstract class AbstractActiveElement extends Basic2DElement
 	{
 		if ( !isActive() ) return;
 
-		if ( dragged ) 
+		if ( dragged )
 		{
 			draggedDistX = clickedMouseX - mx;
 			draggedDistY = clickedMouseY - my;
 		}
 		
 		if ( pressed )
-			mouseReleased( );
-			mouseReleased( mx, my );
+		{
+			final Interactive manager = Interactive.get();
+			if (manager.shouldCallbackWithoutPosition())
+			{
+				mouseReleased( );
+			}
+			if (manager.shouldCallbackWithPosition())
+			{
+				mouseReleased( mx, my );
+			}
+		}
 	}
 	
 	abstract public void mouseReleased ( );

--- a/src/de/bezier/guido/Interactive.java
+++ b/src/de/bezier/guido/Interactive.java
@@ -23,6 +23,39 @@ implements MouseWheelListener
 {
 	private boolean enabled = true;
 
+	/*
+	 * These flags influence which AbstractActiveElement callbacks are called.
+	 * This permits Guido to be used with Jython, and perhaps, in the future,
+	 * other languages that don't support function name overloading by parameter
+	 * signature. 
+	 */
+	public static final int CALLBACKS_POSITION = 1;
+	public static final int CALLBACKS_NO_POSITION = 2;
+	public static final int CALLBACKS_DELTA = 4;
+	public static final int CALLBACKS_NO_DELTA = 8;
+	private int callbackStyle = CALLBACKS_POSITION | CALLBACKS_NO_POSITION | CALLBACKS_DELTA
+			| CALLBACKS_NO_DELTA;
+
+	boolean shouldCallbackWithPosition()
+	{
+		return (callbackStyle & CALLBACKS_POSITION) != 0;
+	}
+
+	boolean shouldCallbackWithoutPosition()
+	{
+		return (callbackStyle & CALLBACKS_NO_POSITION) != 0;
+	}
+
+	boolean shouldCallbackWithDelta()
+	{
+		return (callbackStyle & CALLBACKS_POSITION) != 0;
+	}
+
+	boolean shouldCallbackWithoutDelta()
+	{
+		return (callbackStyle & CALLBACKS_NO_POSITION) != 0;
+	}
+
 	ArrayList<AbstractActiveElement> interActiveElements;
 	private ArrayList<AbstractActiveElement> interActiveElementsList;
 
@@ -78,9 +111,7 @@ implements MouseWheelListener
 	 */
 	public static Interactive make ( PApplet papplet )
 	{
-		if ( manager == null )
-			manager = new Interactive( papplet );
-
+		manager = new Interactive( papplet );
 		return manager;
 	}
 
@@ -102,6 +133,22 @@ implements MouseWheelListener
 	//	static methods, states, utils
 	// ------------------------------------------
 
+	/**
+	 * Tell the Guido system which styles of event callbacks to use.
+	 * 
+	 * @param flags
+	 *					Any bitwise combination of {@link #CALLBACKS_POSITION},
+	 *					{@link #CALLBACKS_NO_POSITION}, {@link #CALLBACKS_DELTA}, and
+	 *					{@link #CALLBACKS_NO_DELTA}.
+	 */
+	public static void setCallbackStyle(final int flags)
+	{
+		if (get() != null)
+		{
+			get().callbackStyle = flags;
+		}
+	}
+	
 	/**
 	 *	Activate or deactivate and interface element.
 	 *
@@ -539,7 +586,7 @@ implements MouseWheelListener
 				mouseExited( evt );
 				break;
 			case processing.event.MouseEvent.WHEEL:
-				mouseWheelMovedImpl( evt.getAmount() );
+				mouseWheelMovedImpl( evt.getCount() );
 				break;
 		}
 


### PR DESCRIPTION
1) Allow `make()` to construct a new `Interactive` instance even if one has
already been constructed.
2) Allow the user to specify which callbacks to call. This is to work
around Jython's inability to overload method names by param signature.
